### PR TITLE
Fix .forceignore preventing QuickAction deploy/retrieve

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -94,7 +94,6 @@ package.xml
 *Aura_Test*
 *cbAura_Test*
 *Default_Navigation*
-*Default*
 *AuraTest*
 *Aura_Test1*
 *MDF_Claim_Request_Crt*


### PR DESCRIPTION
Relaxing slightly the overly aggressive .forceignore options to allow deploy/retrieve of paths with the string "default" in them.

I think this is what is causing the issue of not being able to deploy or retrieve quick action metadata using the sf cli tool.